### PR TITLE
Fix: Corrects typo in wormhole prefab name for Master shard

### DIFF
--- a/latest/overlay/etc/entrypoint.d/20-overrides.sh
+++ b/latest/overlay/etc/entrypoint.d/20-overrides.sh
@@ -427,7 +427,7 @@ case "${DST_OVERRIDE_PRESET}" in
     DST_OVERRIDE_WILDFIRES="default"
     DST_OVERRIDE_WINTER="default"
     DST_OVERRIDE_WORLD_SIZE="default"
-    DST_OVERRIDE_WORMHOLE_PREFAB="workhole"
+    DST_OVERRIDE_WORMHOLE_PREFAB="wormhole"
     ;;
 
   "Caves")


### PR DESCRIPTION
Hi there,

This PR fixes a small but critical typo in the `20-overrides.sh` script that was causing the Master shard to fail during world generation.

**The Problem:**
When creating a new server with a Master shard, the game log shows a repeated error: `[00:00:XX]: Can't find prefab workhole`. This prevents the server from properly spawning wormholes and completing the world setup.

**The Cause:**
The script at `dst/latest/overlay/etc/entrypoint.d/20-overrides.sh` incorrectly sets the default value for the wormhole prefab to `"workhole"` instead of the correct `"wormhole"`.

**The Solution:**
This change corrects the typo in the script, changing `DST_OVERRIDE_WORMHOLE_PREFAB="workhole"` to `DST_OVERRIDE_WORMHOLE_PREFAB="wormhole"`.

This allows the Master shard to start correctly without any errors related to this prefab.

Thanks!